### PR TITLE
Removed reference to phpbrew known --svn

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,11 +107,6 @@ Available stable versions:
     php-5.3.7
 </pre></div>
 
-<p>To list known subversion versions:</p>
-
-<div class="highlight highlight-bash"><pre><span class="nv">$ </span>phpbrew known --svn
-</pre></div>
-
 <p>To list known older versions (less than 5.3):</p>
 
 <div class="highlight highlight-bash"><pre><span class="nv">$ </span>phpbrew known --old


### PR DESCRIPTION
Hello,

The `--svn` option of the `phpbrew known` command does not seem to exist anymore so I removed it.

Best regards,
